### PR TITLE
Added travis checks.

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -5,3 +5,4 @@ cran-comments.md
 ^_pkgdown\.yml$
 ^docs$
 ^pkgdown$
+.travis.yml

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+# R for travis: see documentation at https://docs.travis-ci.com/user/languages/r
+
+language: R
+cache: packages
+warnings_are_errors: true
+
+matrix:
+  include:
+    - r: oldrel
+    - r: release
+    - r: devel
+    - os: osx

--- a/README.Rmd
+++ b/README.Rmd
@@ -19,7 +19,11 @@ library(trackr)
 # trackr
 
 <!-- badges: start -->
+[![Travis build status](https://travis-ci.org/terminological/trackr.svg?branch=master)](https://travis-ci.org/terminological/trackr)
+[![Lifecycle:experimental](https://img.shields.io/badge/lifecycle-experimental-orange.svg)](https://www.tidyverse.org/lifecycle/#experimental)
+<!-- [![CRAN Status](https://www.r-pkg.org/badges/version/trackr)](https://cran.r-project.org/package=trackr) -->
 <!-- badges: end -->
+
 
 I have been known to execute parts of my data pipeline more than once. 
 Sometimes part of my pipeline is designed to change depending on a specific parameter, for example an age cutoff, which I tweak and re-run. 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@
 
 <!-- badges: start -->
 
+[![Travis build
+status](https://travis-ci.org/terminological/trackr.svg?branch=master)](https://travis-ci.org/terminological/trackr)
+[![Lifecycle:experimental](https://img.shields.io/badge/lifecycle-experimental-orange.svg)](https://www.tidyverse.org/lifecycle/#experimental)
+<!-- [![CRAN Status](https://www.r-pkg.org/badges/version/trackr)](https://cran.r-project.org/package=trackr) -->
 <!-- badges: end -->
 
 I have been known to execute parts of my data pipeline more than once.


### PR DESCRIPTION
Added code to perform Travis CI checks if you're interested. You can customise the `.travis.yml` file to test on different OSes each time you push to GitHub, and it includes a build status and lifecycle badge, and also a CRAN badge once you submit to CRAN.

I tested on Mac OSX and it passed, but it failed the Xenial checks (not sure why). It's a useful feature, but you'll have to register with TravisCI, which you can link to GitHub.